### PR TITLE
More robust clean target

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@
 
 CFLAGS=-Wall -O3 -Wextra -pedantic -I $(INSTALL_DIR)/include
 CC=g++
-RM=-rm
+RM=rm -f
 LIB=-lm
 
 # You can have your include files in ~/include and libraries in


### PR DESCRIPTION
Added -f to rm, analogous to makefiles of other source trees of project pluto.

It is only a tiny change, but one that is required to have an idempotent clean target.

Thanks.